### PR TITLE
Semantic analysis

### DIFF
--- a/src/libeval/expression.rs
+++ b/src/libeval/expression.rs
@@ -72,7 +72,7 @@ pub enum Literal {
 }
 
 /// Standalone variable reference.
-#[derive(Debug, Eq, PartialEq)]
+#[derive(Clone, Debug, Eq, PartialEq)]
 pub struct Variable {
     /// Name of the variable.
     pub name: Atom,

--- a/src/libeval/lib.rs
+++ b/src/libeval/lib.rs
@@ -14,3 +14,4 @@ extern crate reader;
 
 pub mod expression;
 pub mod expanders;
+pub mod meaning;

--- a/src/libeval/meaning.rs
+++ b/src/libeval/meaning.rs
@@ -1,0 +1,30 @@
+// Copyright (c) 2017, Sabre developers
+//
+// Licensed under the Apache License, Version 2.0 (see LICENSE.Apache in the
+// root directory) or MIT license (see LICENSE.MIT in the root directory),
+// at your option. This file may be copied, distributed, and modified only
+// in accordance with the terms specified by the chosen license.
+
+//! Scheme expression analyzer.
+//!
+//! Here we transform core Scheme expressions into their meaning based on the semantics of Scheme.
+//! This is the finish line of the front-end.
+
+use locus::diagnostics::{Span};
+
+use expression::{Expression};
+
+pub trait Environment {
+}
+
+pub struct Meaning {
+    kind: MeaningKind,
+    span: Option<Span>,
+}
+
+pub enum MeaningKind {
+}
+
+pub fn meaning(expression: &Expression, environment: &Environment) -> Meaning {
+    unimplemented!()
+}

--- a/src/libeval/meaning.rs
+++ b/src/libeval/meaning.rs
@@ -10,6 +10,7 @@
 //! Here we transform core Scheme expressions into their meaning based on the semantics of Scheme.
 //! This is the finish line of the front-end.
 
+use std::fmt;
 use std::rc::{Rc};
 use std::slice;
 
@@ -118,6 +119,51 @@ pub enum MeaningKind {
     Sequence(Vec<Meaning>),
     ClosureFixed(usize, Box<Meaning>),
     ProcedureCall(Box<Meaning>, Vec<Meaning>),
+}
+
+impl fmt::Debug for Meaning {
+    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+        match self.kind {
+            MeaningKind::Undefined =>
+                write!(f, "(Undefined)"),
+            MeaningKind::Constant(index) =>
+                write!(f, "(Constant {})", index),
+            MeaningKind::ShallowArgumentReference(index) =>
+                write!(f, "(ShallowArgumentReference {})", index),
+            MeaningKind::DeepArgumentReference(depth, index) =>
+                write!(f, "(DeepArgumentReference {} {})", depth, index),
+            MeaningKind::GlobalReference(index) =>
+                write!(f, "(GlobalReference {})", index),
+            MeaningKind::ImportedReference(index) =>
+                write!(f, "(ImportedReference {})", index),
+            MeaningKind::Alternative(ref condition, ref consequent, ref alternate) =>
+                write!(f, "(Alternative {:?} {:?} {:?})", condition, consequent, alternate),
+            MeaningKind::ShallowArgumentSet(index, ref value) =>
+                write!(f, "(ShallowArgumentSet {} {:?})", index, value),
+            MeaningKind::DeepArgumentSet(depth, index, ref value) =>
+                write!(f, "(DeepArgumentSet {} {} {:?})", depth, index, value),
+            MeaningKind::GlobalSet(index, ref value) =>
+                write!(f, "(GlobalSet {} {:?})", index, value),
+            MeaningKind::Sequence(ref computations) => {
+                try!(write!(f, "(Sequence"));
+                for c in computations {
+                    try!(write!(f, " {:?}", c));
+                }
+                try!(write!(f, ")"));
+                Ok(())
+            }
+            MeaningKind::ClosureFixed(arg_count, ref body) =>
+                write!(f, "(ClosureFixed {} {:?})", arg_count, body),
+            MeaningKind::ProcedureCall(ref procedure, ref args) => {
+                try!(write!(f, "(ProcedureCall {:?}", procedure));
+                for a in args {
+                    try!(write!(f, " {:?}", a));
+                }
+                try!(write!(f, ")"));
+                Ok(())
+            }
+        }
+    }
 }
 
 pub enum Value {

--- a/src/libeval/meaning.rs
+++ b/src/libeval/meaning.rs
@@ -11,20 +11,47 @@
 //! This is the finish line of the front-end.
 
 use locus::diagnostics::{Span};
+use reader::intern_pool::{Atom};
 
-use expression::{Expression};
+use expression::{Expression, ExpressionKind, Literal};
 
 pub trait Environment {
 }
 
 pub struct Meaning {
-    kind: MeaningKind,
-    span: Option<Span>,
+    pub kind: MeaningKind,
+    pub span: Option<Span>,
 }
 
 pub enum MeaningKind {
+    Constant(Value),
+}
+
+pub enum Value {
+    Boolean(bool),
+    Number(Atom),
+    Character(char),
+    String(Atom),
 }
 
 pub fn meaning(expression: &Expression, environment: &Environment) -> Meaning {
-    unimplemented!()
+    match expression.kind {
+        ExpressionKind::Literal(ref value) => meaning_literal(value, &expression.span),
+        _ => unimplemented!(),
+    }
+}
+
+fn meaning_literal(value: &Literal, span: &Option<Span>) -> Meaning {
+    Meaning {
+        kind: MeaningKind::Constant(
+            match *value {
+                Literal::Boolean(value) => Value::Boolean(value),
+                Literal::Number(value) => Value::Number(value),
+                Literal::Character(value) => Value::Character(value),
+                Literal::String(value) => Value::String(value),
+                _ => unimplemented!(),
+            }
+        ),
+        span: span.clone(),
+    }
 }

--- a/src/libeval/meaning.rs
+++ b/src/libeval/meaning.rs
@@ -11,6 +11,7 @@
 //! This is the finish line of the front-end.
 
 use std::rc::{Rc};
+use std::slice;
 
 use locus::diagnostics::{Span, Handler, DiagnosticKind};
 use reader::datum::{ScannedDatum, DatumValue};
@@ -130,20 +131,112 @@ pub struct MeaningResult {
     pub sequence: Meaning,
 }
 
+struct SequenceSplicingIterator<'a> {
+    current: Option<slice::Iter<'a, Expression>>,
+    postponed: Vec<slice::Iter<'a, Expression>>,
+}
+
+// I personally consider the splicing role of the (begin term ...) form to be a wart on Scheme
+// syntax and semantics. It could have been better if it was named "splice". Or did not exist
+// at all.
+//
+// The splicing "begin" form is not very consistent with the sequencing role of the (begin expr1
+// exprs ...) form, the 'implicit sequence' of top-level expressions, and the 'internal
+// definitions' introduced by lambda forms and syntax derived from them (e.g., letrec). It feels
+// that this form was introduced and maintainined purely because of historical reasons.
+//
+// The main motivation for the splicing "begin" are macros. It is a desirable feature for macros
+// to be able to introduce definitions that are visible outside of the immediately expanded
+// expression: e.g., define-values define multiple variables which are accessible to expressions
+// that come after the "define-values" form.
+//
+// However, this can be achieved by allowing macros to expand into multiple terms which are then
+// spliced into the expansion site. There is no need for a new special form "splice" or for
+// overloaded "begin" to achieve that.
+//
+// With this,
+// - "begin" form has only one meaning
+// - macros still have rewriting as expansion-time semantics
+// - splicing magic is still there if you need it
+// - macros do not introduce an implicit scope when they are expanded
+// - something like (let () ...) can be used to explicitly delimit the lexical scope for internal
+//   definitons if needed
+//
+// But instead we have a splicing "begin" and have to support it. It sucks to be backwards-
+// compatible and to eat histerical raisins, I guess.
+//
+// Either way, Abathur would certainly like this function name, so that alone justifies it.
+fn splice_in_sequences<'a>(expressions: &'a [Expression]) -> SequenceSplicingIterator<'a> {
+    SequenceSplicingIterator {
+        current: Some(expressions.iter()),
+        postponed: Vec::new(),
+    }
+}
+
+impl<'a> Iterator for SequenceSplicingIterator<'a> {
+    type Item = &'a Expression;
+
+    fn next(&mut self) -> Option<&'a Expression> {
+        loop {
+            // If there is an iterator we're currently walking through then take it.
+            // Otherwise we're done and there is nothing to do anymore. Note that
+            // we have to *not* borrow self.current as we may need to change it later.
+            if let Some(mut iter) = self.current.take() {
+                // If the current iterator still has some values in it then take them.
+                // Otherwise get back to postponed iterators and try again with them.
+                if let Some(expression) = iter.next() {
+                    // If the next expression is a sequence then instead of returning it
+                    // splice its elements in by iterating over them now and getting back
+                    // to the previous iterator later.
+                    if let ExpressionKind::Sequence(ref expressions) = expression.kind {
+                        self.postponed.push(iter);
+                        self.current = Some(expressions.iter());
+                        continue;
+                    }
+                    self.current = Some(iter);
+                    return Some(expression);
+                }
+                self.current = self.postponed.pop();
+                continue;
+            }
+            return None;
+        }
+    }
+}
+
 pub fn meaning(
     diagnostic: &Handler,
     expressions: &[Expression],
     environment: &Rc<Environment>) -> MeaningResult
 {
-    let sequence = expressions.iter()
-        .map(|e| meaning_expression(diagnostic, e, environment))
-        .collect();
-
     MeaningResult {
-        sequence: Meaning {
-            kind: MeaningKind::Sequence(sequence),
-            span: None,
-        },
+        sequence: meaning_body(diagnostic, expressions, environment),
+    }
+}
+
+fn meaning_body(
+    diagnostic: &Handler,
+    expressions: &[Expression],
+    environment: &Rc<Environment>) -> Meaning
+{
+    Meaning {
+        kind: MeaningKind::Sequence(
+            splice_in_sequences(expressions)
+                .map(|e| meaning_expression(diagnostic, e, &environment))
+                .collect()
+        ),
+        span: expressions_span(expressions),
+    }
+}
+
+fn expressions_span(expressions: &[Expression]) -> Option<Span> {
+    let first = expressions.first().map(|e| e.span).unwrap_or(None);
+    let last = expressions.last().map(|e| e.span).unwrap_or(None);
+
+    if let (Some(first), Some(last)) = (first, last) {
+        Some(Span::new(first.from, last.to))
+    } else {
+        None
     }
 }
 
@@ -317,19 +410,7 @@ fn meaning_abstraction_fixed(
 {
     let new_environment = Environment::new_local(arguments, environment);
 
-    let body_begin = body.first().unwrap().span;
-    let body_end = body.last().unwrap().span;
-    let body_span =
-        if let (Some(span_begin), Some(span_end)) = (body_begin, body_end) {
-            Some(Span::new(span_begin.from, span_end.to))
-        } else {
-            None
-        };
-
-    return Meaning {
-        kind: meaning_sequence(diagnostic, body, &new_environment),
-        span: body_span,
-    };
+    meaning_body(diagnostic, body, &new_environment)
 }
 
 fn meaning_application(

--- a/src/libeval/meaning.rs
+++ b/src/libeval/meaning.rs
@@ -10,14 +10,25 @@
 //! Here we transform core Scheme expressions into their meaning based on the semantics of Scheme.
 //! This is the finish line of the front-end.
 
+use std::rc::{Rc};
+
 use locus::diagnostics::{Span};
 use reader::datum::{ScannedDatum, DatumValue};
 use reader::intern_pool::{Atom};
 
 use expression::{Expression, ExpressionKind, Literal, Variable, Arguments};
 
-pub trait Environment {
-    fn resolve_variable(&self, name: Atom) -> VariableKind;
+pub struct Environment {
+    kind: EnvironmentKind,
+    variables: Vec<Variable>,
+    parent: Option<Rc<Environment>>,
+}
+
+#[derive(Eq, PartialEq)]
+enum EnvironmentKind {
+    Local,
+    Global,
+    Imported,
 }
 
 pub enum VariableKind {
@@ -32,6 +43,59 @@ pub enum VariableKind {
         index: usize,
     },
     Unresolved,
+}
+
+impl Environment {
+    pub fn new_local(variables: &[Variable], parent: &Rc<Environment>) -> Rc<Environment> {
+        Rc::new(Environment {
+            kind: EnvironmentKind::Local,
+            variables: variables.to_vec(),
+            parent: Some(parent.clone()),
+        })
+    }
+
+    pub fn new_global(variables: &[Variable], parent: &Rc<Environment>) -> Rc<Environment> {
+        assert!(parent.kind == EnvironmentKind::Imported);
+        Rc::new(Environment {
+            kind: EnvironmentKind::Global,
+            variables: variables.to_vec(),
+            parent: Some(parent.clone()),
+        })
+    }
+
+    pub fn new_imported(variables: &[Variable]) -> Rc<Environment> {
+        Rc::new(Environment {
+            kind: EnvironmentKind::Imported,
+            variables: variables.to_vec(),
+            parent: None,
+        })
+    }
+
+    pub fn resolve_variable(&self, name: Atom) -> VariableKind {
+        // First, try to resolve the name locally.
+        for (index, local) in self.variables.iter().enumerate() {
+            if name == local.name {
+                return match self.kind {
+                    EnvironmentKind::Local => VariableKind::Local { index, depth: 0 },
+                    EnvironmentKind::Global => VariableKind::Global { index },
+                    EnvironmentKind::Imported => VariableKind::Imported { index },
+                };
+            }
+        }
+
+        // If that fails then look into parent environment (if it's available).
+        if let Some(ref parent) = self.parent {
+            let mut variable = parent.resolve_variable(name);
+            // Bump the nesting depth for local variables.
+            if let VariableKind::Local { ref mut depth, .. } = variable {
+                *depth += 1;
+            }
+            return variable;
+        }
+
+        // The variable cannot be resolved if it is absent in all environments.
+        return VariableKind::Unresolved;
+    }
 }
 
 pub struct Meaning {
@@ -61,7 +125,7 @@ pub enum Value {
     String(Atom),
 }
 
-pub fn meaning(expression: &Expression, environment: &Environment) -> Meaning {
+pub fn meaning(expression: &Expression, environment: &Rc<Environment>) -> Meaning {
     Meaning {
         kind: match expression.kind {
             ExpressionKind::Literal(ref value) =>
@@ -109,7 +173,7 @@ fn meaning_quote(datum: &ScannedDatum) -> MeaningKind {
     )
 }
 
-fn meaning_reference(name: Atom, environment: &Environment) -> MeaningKind {
+fn meaning_reference(name: Atom, environment: &Rc<Environment>) -> MeaningKind {
     match environment.resolve_variable(name)  {
         VariableKind::Local { depth, index } => {
             if depth == 0 {
@@ -133,7 +197,7 @@ fn meaning_reference(name: Atom, environment: &Environment) -> MeaningKind {
 }
 
 fn meaning_alternative(condition: &Expression, consequent: &Expression, alternate: &Expression,
-    environment: &Environment) -> MeaningKind
+    environment: &Rc<Environment>) -> MeaningKind
 {
     MeaningKind::Alternative(
         Box::new(meaning(condition, environment)),
@@ -143,7 +207,7 @@ fn meaning_alternative(condition: &Expression, consequent: &Expression, alternat
 }
 
 fn meaning_assignment(variable: &Variable, value: &Expression,
-    environment: &Environment) -> MeaningKind
+    environment: &Rc<Environment>) -> MeaningKind
 {
     // Note that we use the same environment, not extended with the variable name.
     let new_value = Box::new(meaning(value, environment));
@@ -172,7 +236,7 @@ fn meaning_assignment(variable: &Variable, value: &Expression,
     }
 }
 
-fn meaning_sequence(expressions: &[Expression], environment: &Environment) -> MeaningKind {
+fn meaning_sequence(expressions: &[Expression], environment: &Rc<Environment>) -> MeaningKind {
     assert!(expressions.len() >= 1, "BUG: (begin) not handled");
 
     MeaningKind::Sequence(
@@ -183,7 +247,7 @@ fn meaning_sequence(expressions: &[Expression], environment: &Environment) -> Me
 }
 
 fn meaning_abstraction(arguments: &Arguments, body: &[Expression],
-    environment: &Environment) -> MeaningKind
+    environment: &Rc<Environment>) -> MeaningKind
 {
     match *arguments {
         Arguments::Fixed(ref variables) =>
@@ -194,9 +258,9 @@ fn meaning_abstraction(arguments: &Arguments, body: &[Expression],
 }
 
 fn meaning_abstraction_fixed(arguments: &[Variable], body: &[Expression],
-    environment: &Environment) -> Meaning
+    environment: &Rc<Environment>) -> Meaning
 {
-    let new_environment = FixedVariableEnvironment::new(arguments, environment);
+    let new_environment = Environment::new_local(arguments, environment);
 
     let body_begin = body.first().unwrap().span;
     let body_end = body.last().unwrap().span;
@@ -213,39 +277,7 @@ fn meaning_abstraction_fixed(arguments: &[Variable], body: &[Expression],
     };
 }
 
-struct FixedVariableEnvironment<'a> {
-    variables: &'a [Variable],
-    upper: &'a Environment,
-}
-
-impl<'a> FixedVariableEnvironment<'a> {
-    fn new(variables: &'a [Variable], upper: &'a Environment) -> FixedVariableEnvironment<'a> {
-        FixedVariableEnvironment {
-            variables: variables,
-            upper: upper,
-        }
-    }
-}
-
-impl<'a> Environment for FixedVariableEnvironment<'a> {
-    fn resolve_variable(&self, name: Atom) -> VariableKind {
-        for (index, local) in self.variables.iter().enumerate() {
-            if name == local.name {
-                return VariableKind::Local { depth: 0, index: index };
-            }
-        }
-
-        let upper_result = self.upper.resolve_variable(name);
-
-        return if let VariableKind::Local { depth, index } = upper_result {
-            VariableKind::Local { depth: depth + 1, index: index }
-        } else {
-            upper_result
-        };
-    }
-}
-
-fn meaning_application(terms: &[Expression], environment: &Environment) -> MeaningKind {
+fn meaning_application(terms: &[Expression], environment: &Rc<Environment>) -> MeaningKind {
     assert!(terms.len() >= 1, "BUG: empty application");
 
     let procedure = Box::new(meaning(&terms[0], environment));

--- a/src/libeval/meaning.rs
+++ b/src/libeval/meaning.rs
@@ -166,6 +166,7 @@ impl fmt::Debug for Meaning {
     }
 }
 
+#[derive(Debug, PartialEq, Eq)]
 pub enum Value {
     Boolean(bool),
     Number(Atom),

--- a/src/libeval/meaning.rs
+++ b/src/libeval/meaning.rs
@@ -45,6 +45,7 @@ pub enum MeaningKind {
     DeepArgumentReference(usize, usize),
     GlobalReference(usize),
     ImportedReference(usize),
+    Alternative(Box<Meaning>, Box<Meaning>, Box<Meaning>),
 }
 
 pub enum Value {
@@ -59,6 +60,8 @@ pub fn meaning(expression: &Expression, environment: &Environment) -> Meaning {
         ExpressionKind::Literal(ref value) => meaning_literal(value, &expression.span),
         ExpressionKind::Quotation(ref datum) => meaning_quote(datum, &expression.span),
         ExpressionKind::Reference(name) => meaning_reference(name, environment, &expression.span),
+        ExpressionKind::Alternative(ref condition, ref consequent, ref alternate) =>
+            meaning_alternative(condition, consequent, alternate, environment, &expression.span),
         _ => unimplemented!(),
     }
 }
@@ -115,6 +118,19 @@ fn meaning_reference(name: Atom, environment: &Environment, span: &Option<Span>)
                 unimplemented!()
             }
         },
+        span: span.clone(),
+    }
+}
+
+fn meaning_alternative(condition: &Expression, consequent: &Expression, alternate: &Expression,
+    environment: &Environment, span: &Option<Span>) -> Meaning
+{
+    Meaning {
+        kind: MeaningKind::Alternative(
+            Box::new(meaning(condition, environment)),
+            Box::new(meaning(consequent, environment)),
+            Box::new(meaning(alternate, environment)),
+        ),
         span: span.clone(),
     }
 }

--- a/src/libeval/meaning.rs
+++ b/src/libeval/meaning.rs
@@ -49,6 +49,7 @@ pub enum MeaningKind {
     ShallowArgumentSet(usize, Box<Meaning>),
     DeepArgumentSet(usize, usize, Box<Meaning>),
     GlobalSet(usize, Box<Meaning>),
+    Sequence(Vec<Meaning>),
 }
 
 pub enum Value {
@@ -67,6 +68,8 @@ pub fn meaning(expression: &Expression, environment: &Environment) -> Meaning {
             meaning_alternative(condition, consequent, alternate, environment, &expression.span),
         ExpressionKind::Assignment(ref variable, ref value) =>
             meaning_assignment(variable, value.as_ref(), environment, &expression.span),
+        ExpressionKind::Sequence(ref expressions) =>
+            meaning_sequence(expressions, environment, &expression.span),
         _ => unimplemented!(),
     }
 }
@@ -169,6 +172,23 @@ fn meaning_assignment(variable: &Variable, value: &Expression, environment: &Env
                 unimplemented!()
             }
         },
+        span: span.clone(),
+    }
+}
+
+fn meaning_sequence(expressions: &[Expression], environment: &Environment, span: &Option<Span>)
+    -> Meaning
+{
+    if expressions.len() == 0 {
+        panic!("BUG: (begin) not handled");
+    }
+
+    Meaning {
+        kind: MeaningKind::Sequence(
+            expressions.iter()
+                       .map(|e| meaning(e, environment))
+                       .collect()
+        ),
         span: span.clone(),
     }
 }

--- a/src/libeval/meaning.rs
+++ b/src/libeval/meaning.rs
@@ -11,6 +11,7 @@
 //! This is the finish line of the front-end.
 
 use locus::diagnostics::{Span};
+use reader::datum::{ScannedDatum, DatumValue};
 use reader::intern_pool::{Atom};
 
 use expression::{Expression, ExpressionKind, Literal};
@@ -37,6 +38,7 @@ pub enum Value {
 pub fn meaning(expression: &Expression, environment: &Environment) -> Meaning {
     match expression.kind {
         ExpressionKind::Literal(ref value) => meaning_literal(value, &expression.span),
+        ExpressionKind::Quotation(ref datum) => meaning_quote(datum, &expression.span),
         _ => unimplemented!(),
     }
 }
@@ -49,6 +51,21 @@ fn meaning_literal(value: &Literal, span: &Option<Span>) -> Meaning {
                 Literal::Number(value) => Value::Number(value),
                 Literal::Character(value) => Value::Character(value),
                 Literal::String(value) => Value::String(value),
+                _ => unimplemented!(),
+            }
+        ),
+        span: span.clone(),
+    }
+}
+
+fn meaning_quote(datum: &ScannedDatum, span: &Option<Span>) -> Meaning {
+    Meaning {
+        kind: MeaningKind::Constant(
+            match datum.value {
+                DatumValue::Boolean(value) => Value::Boolean(value),
+                DatumValue::Number(value) => Value::Number(value),
+                DatumValue::Character(value) => Value::Character(value),
+                DatumValue::String(value) => Value::String(value),
                 _ => unimplemented!(),
             }
         ),

--- a/src/libeval/tests/meaning.rs
+++ b/src/libeval/tests/meaning.rs
@@ -13,7 +13,7 @@ extern crate eval;
 extern crate locus;
 extern crate reader;
 
-use eval::meaning::{meaning, Meaning, MeaningResult, MeaningKind, Value};
+use eval::meaning::{meaning, MeaningResult, Value};
 
 // - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
 // Tested expanders and environments
@@ -359,7 +359,7 @@ fn check(input: &str, output: &str, expected_diagnostics: &[Diagnostic]) {
     let expressions = expand(&pool, &data);
     let (meaning, diagnostics) = treat(&pool, &expressions);
 
-    let actual = pretty_print(&meaning.sequence);
+    let actual = format!("{:?}", meaning.sequence);
 
     assert_eq!(trim_space(&actual), trim_space(output));
     assert_eq!(diagnostics, expected_diagnostics);
@@ -416,104 +416,6 @@ fn treat(pool: &InternPool, expressions: &[Expression]) -> (MeaningResult, Vec<D
 
 // - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
 // Pretty-printing meanings
-
-fn pretty_print(meaning: &Meaning) -> String {
-    match meaning.kind {
-        MeaningKind::Undefined => pretty_print_undefined(),
-        MeaningKind::Constant(index) => pretty_print_constant(index),
-        MeaningKind::ShallowArgumentReference(index) => pretty_print_shallow_reference(index),
-        MeaningKind::DeepArgumentReference(depth, index) => pretty_print_deep_reference(depth, index),
-        MeaningKind::GlobalReference(index) => pretty_print_global_reference(index),
-        MeaningKind::ImportedReference(index) => pretty_print_imported_reference(index),
-        MeaningKind::Alternative(ref condition, ref consequent, ref alternate) =>
-            pretty_print_alternative(condition, consequent, alternate),
-        MeaningKind::ShallowArgumentSet(index, ref value) =>
-            pretty_print_shallow_set(index, value.as_ref()),
-        MeaningKind::DeepArgumentSet(depth, index, ref value) =>
-            pretty_print_deep_set(depth, index, value.as_ref()),
-        MeaningKind::GlobalSet(index, ref value) =>
-            pretty_print_global_set(index, value.as_ref()),
-        MeaningKind::Sequence(ref computations) =>
-            pretty_print_sequence(computations),
-        MeaningKind::ClosureFixed(arg_count, ref body) =>
-            pretty_print_closure_fixed(arg_count, body.as_ref()),
-        MeaningKind::ProcedureCall(ref procedure, ref args) =>
-            pretty_print_procedure_call(procedure.as_ref(), args.as_ref()),
-    }
-}
-
-fn pretty_print_undefined() -> String {
-    format!("(Undefined)")
-}
-
-fn pretty_print_constant(index: usize) -> String {
-    format!("(Constant {})", index)
-}
-
-fn pretty_print_shallow_reference(index: usize) -> String {
-    format!("(ShallowArgumentReference {})", index)
-}
-
-fn pretty_print_deep_reference(depth: usize, index: usize) -> String {
-    format!("(DeepArgumentReference {} {})", depth, index)
-}
-
-fn pretty_print_global_reference(index: usize) -> String {
-    format!("(GlobalReference {})", index)
-}
-
-fn pretty_print_imported_reference(index: usize) -> String {
-    format!("(ImportedReference {})", index)
-}
-
-fn pretty_print_alternative(condition: &Meaning, consequent: &Meaning,
-    alternate: &Meaning) -> String
-{
-    format!("(Alternative {} {} {})",
-        pretty_print(condition),
-        pretty_print(consequent),
-        pretty_print(alternate)
-    )
-}
-
-fn pretty_print_shallow_set(index: usize, value: &Meaning) -> String {
-    format!("(ShallowArgumentSet {} {})", index, pretty_print(value))
-}
-
-fn pretty_print_deep_set(depth: usize, index: usize, value: &Meaning) -> String {
-    format!("(DeepArgumentSet {} {} {})", depth, index, pretty_print(value))
-}
-
-fn pretty_print_global_set(index: usize, value: &Meaning) -> String {
-    format!("(GlobalSet {} {})", index, pretty_print(value))
-}
-
-fn pretty_print_sequence(computations: &[Meaning]) -> String {
-    let mut s = String::new();
-    s.push_str("(Sequence");
-    for c in computations {
-        s.push_str(" ");
-        s.push_str(&pretty_print(c));
-    }
-    s.push_str(")");
-    return s;
-}
-
-fn pretty_print_closure_fixed(args_count: usize, body: &Meaning) -> String {
-    format!("(ClosureFixed {} {})", args_count, pretty_print(body))
-}
-
-fn pretty_print_procedure_call(procedure: &Meaning, args: &[Meaning]) -> String {
-    let mut s = String::new();
-    s.push_str("(ProcedureCall ");
-    s.push_str(&pretty_print(procedure));
-    for a in args {
-        s.push_str(" ");
-        s.push_str(&pretty_print(a));
-    }
-    s.push_str(")");
-    return s;
-}
 
 fn trim_space(sexpr: &str) -> String {
     enum State {

--- a/src/libeval/tests/meaning.rs
+++ b/src/libeval/tests/meaning.rs
@@ -194,24 +194,47 @@ fn assignment_imported() {
 #[test]
 fn sequence_simple() {
     check("(begin 1 2 3)",
-        "(Sequence (Sequence (Constant 1) (Constant 2) (Constant 3)))",
+        "(Sequence (Constant 1) (Constant 2) (Constant 3))",
         &[]
     );
 }
 
 #[test]
-fn sequence_nested() {
+fn sequence_splicing_toplevel() {
     check("(begin (begin #f #f #t) (if #f 1 2) (begin 9))",
         "(Sequence
-            (Sequence
+            (Constant #f)
+            (Constant #f)
+            (Constant #t)
+            (Alternative (Constant #f)
+                (Constant 1)
+                (Constant 2))
+            (Constant 9))",
+        &[]
+    );
+}
+
+#[test]
+fn sequence_splicing_inner() {
+    check("(lambda () (begin #f #f #t) (begin (begin 1)))",
+        "(Sequence
+            (ClosureFixed 0
                 (Sequence
                     (Constant #f)
                     (Constant #f)
-                    (Constant #t))
-                (Alternative (Constant #f)
-                    (Constant 1)
-                    (Constant 2))
-                (Sequence (Constant 9))))",
+                    (Constant #t)
+                    (Constant 1))))",
+        &[]
+    );
+}
+
+#[test]
+fn sequence_nonsplicing() {
+    check("(if *global* (begin 1 2) (begin 3))",
+        "(Sequence
+            (Alternative (GlobalReference 0)
+                (Sequence (Constant 1) (Constant 2))
+                (Sequence (Constant 3))))",
         &[]
     );
 }

--- a/src/libeval/tests/meaning.rs
+++ b/src/libeval/tests/meaning.rs
@@ -60,18 +60,18 @@ fn basic_scheme_environment(pool: &InternPool) -> Rc<Environment> {
 
 #[test]
 fn literals() {
-    check("42",         "(Sequence (Constant 42))",         &[]);
-    check("#\\x",       "(Sequence (Constant #\\x))",       &[]);
-    check("#false",     "(Sequence (Constant #f))",         &[]);
-    check("\"string\"", "(Sequence (Constant \"string\"))", &[]);
+    check("42",         "(Sequence (Constant 0))", &[]);
+    check("#\\x",       "(Sequence (Constant 0))", &[]);
+    check("#false",     "(Sequence (Constant 0))", &[]);
+    check("\"string\"", "(Sequence (Constant 0))", &[]);
 }
 
 #[test]
 fn quote_literals() {
-    check("'123",         "(Sequence (Constant 123))",  &[]);
-    check("(quote #\\!)", "(Sequence (Constant #\\!))", &[]);
-    check("'#t",          "(Sequence (Constant #t))",   &[]);
-    check("(quote \"\")", "(Sequence (Constant \"\"))", &[]);
+    check("'123",         "(Sequence (Constant 0))", &[]);
+    check("(quote #\\!)", "(Sequence (Constant 0))", &[]);
+    check("'#t",          "(Sequence (Constant 0))", &[]);
+    check("(quote \"\")", "(Sequence (Constant 0))", &[]);
 }
 
 // - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
@@ -104,8 +104,8 @@ fn reference_undefined() {
 
 #[test]
 fn alternative() {
-    check("(if #t 1 0)",
-        "(Sequence (Alternative (Constant #t) (Constant 1) (Constant 0)))",
+    check("(if #t 111 222)",
+        "(Sequence (Alternative (Constant 0) (Constant 1) (Constant 2)))",
         &[]
     );
     check("(if *global* car cdr)",
@@ -119,13 +119,13 @@ fn alternative() {
 
 #[test]
 fn alternative_nested() {
-    check("(if (if #f 1 #f) 1 0)",
+    check("(if (if #f 111 #t) 222 333)",
         "(Sequence
-            (Alternative (Alternative (Constant #f)
+            (Alternative (Alternative (Constant 0)
                             (Constant 1)
-                            (Constant #f))
-                (Constant 1)
-                (Constant 0)))",
+                            (Constant 2))
+                (Constant 3)
+                (Constant 4)))",
         &[]
     );
 }
@@ -147,8 +147,8 @@ fn assignment_global() {
 
 #[test]
 fn assignment_undefined() {
-    check("(set! undefined 1)",
-        "(Sequence (Constant 1))",
+    check("(set! undefined 111)",
+        "(Sequence (Constant 0))",
         &[
             Diagnostic {
                 kind: DiagnosticKind::err_meaning_unresolved_variable,
@@ -193,8 +193,8 @@ fn assignment_imported() {
 
 #[test]
 fn sequence_simple() {
-    check("(begin 1 2 3)",
-        "(Sequence (Constant 1) (Constant 2) (Constant 3))",
+    check("(begin 111 222 333)",
+        "(Sequence (Constant 0) (Constant 1) (Constant 2))",
         &[]
     );
 }
@@ -203,13 +203,13 @@ fn sequence_simple() {
 fn sequence_splicing_toplevel() {
     check("(begin (begin #f #f #t) (if #f 1 2) (begin 9))",
         "(Sequence
-            (Constant #f)
-            (Constant #f)
-            (Constant #t)
-            (Alternative (Constant #f)
-                (Constant 1)
-                (Constant 2))
-            (Constant 9))",
+            (Constant 0)
+            (Constant 1)
+            (Constant 2)
+            (Alternative (Constant 3)
+                (Constant 4)
+                (Constant 5))
+            (Constant 6))",
         &[]
     );
 }
@@ -220,10 +220,10 @@ fn sequence_splicing_inner() {
         "(Sequence
             (ClosureFixed 0
                 (Sequence
-                    (Constant #f)
-                    (Constant #f)
-                    (Constant #t)
-                    (Constant 1))))",
+                    (Constant 0)
+                    (Constant 1)
+                    (Constant 2)
+                    (Constant 3))))",
         &[]
     );
 }
@@ -233,8 +233,8 @@ fn sequence_nonsplicing() {
     check("(if *global* (begin 1 2) (begin 3))",
         "(Sequence
             (Alternative (GlobalReference 0)
-                (Sequence (Constant 1) (Constant 2))
-                (Sequence (Constant 3))))",
+                (Sequence (Constant 0) (Constant 1))
+                (Sequence (Constant 2))))",
         &[]
     );
 }
@@ -245,11 +245,11 @@ fn sequence_nonsplicing() {
 #[test]
 fn lambda_no_arguments() {
     check("(lambda () #t)",
-        "(Sequence (ClosureFixed 0 (Sequence (Constant #t))))",
+        "(Sequence (ClosureFixed 0 (Sequence (Constant 0))))",
         &[]
     );
     check("(lambda () 1 2 3)",
-        "(Sequence (ClosureFixed 0 (Sequence (Constant 1) (Constant 2) (Constant 3))))",
+        "(Sequence (ClosureFixed 0 (Sequence (Constant 0) (Constant 1) (Constant 2))))",
         &[]
     );
 }
@@ -261,8 +261,8 @@ fn lambda_fixed_arguments() {
             (ClosureFixed 1
                 (Sequence
                     (Alternative (ShallowArgumentReference 0)
-                        (Sequence (Constant 2) (Constant 3))
-                        (Constant #f)))))",
+                        (Sequence (Constant 0) (Constant 1))
+                        (Constant 2)))))",
         &[]
     );
 }
@@ -309,26 +309,26 @@ fn lambda_undefined_locals() {
 
 #[test]
 fn application_simple() {
-    check("(cons 1 2)",
+    check("(cons 111 222)",
         "(Sequence
-            (ProcedureCall (ImportedReference 2) (Constant 1) (Constant 2)))",
+            (ProcedureCall (ImportedReference 2) (Constant 0) (Constant 1)))",
         &[]
     );
 }
 
 #[test]
 fn application_nested() {
-    check("(car (cons 1 2))",
+    check("(car (cons 111 222))",
         "(Sequence
             (ProcedureCall (ImportedReference 0)
-                (ProcedureCall (ImportedReference 2) (Constant 1) (Constant 2))))",
+                (ProcedureCall (ImportedReference 2) (Constant 0) (Constant 1))))",
         &[]
     );
 }
 
 #[test]
 fn application_closed() {
-    check("((lambda (a b) (cons a b)) 1 2)",
+    check("((lambda (a b) (cons a b)) 111 222)",
         "(Sequence
             (ProcedureCall
                 (ClosureFixed 2
@@ -336,8 +336,8 @@ fn application_closed() {
                         (ProcedureCall (ImportedReference 2)
                             (ShallowArgumentReference 0)
                             (ShallowArgumentReference 1))))
-                (Constant 1)
-                (Constant 2)))",
+                (Constant 0)
+                (Constant 1)))",
         &[]
     );
 }
@@ -359,7 +359,7 @@ fn check(input: &str, output: &str, expected_diagnostics: &[Diagnostic]) {
     let expressions = expand(&pool, &data);
     let (meaning, diagnostics) = treat(&pool, &expressions);
 
-    let actual = pretty_print(&pool, &meaning.sequence);
+    let actual = pretty_print(&meaning.sequence);
 
     assert_eq!(trim_space(&actual), trim_space(output));
     assert_eq!(diagnostics, expected_diagnostics);
@@ -417,28 +417,28 @@ fn treat(pool: &InternPool, expressions: &[Expression]) -> (MeaningResult, Vec<D
 // - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
 // Pretty-printing meanings
 
-fn pretty_print(pool: &InternPool, meaning: &Meaning) -> String {
+fn pretty_print(meaning: &Meaning) -> String {
     match meaning.kind {
         MeaningKind::Undefined => pretty_print_undefined(),
-        MeaningKind::Constant(ref value) => pretty_print_constant(pool, value),
+        MeaningKind::Constant(index) => pretty_print_constant(index),
         MeaningKind::ShallowArgumentReference(index) => pretty_print_shallow_reference(index),
         MeaningKind::DeepArgumentReference(depth, index) => pretty_print_deep_reference(depth, index),
         MeaningKind::GlobalReference(index) => pretty_print_global_reference(index),
         MeaningKind::ImportedReference(index) => pretty_print_imported_reference(index),
         MeaningKind::Alternative(ref condition, ref consequent, ref alternate) =>
-            pretty_print_alternative(pool, condition, consequent, alternate),
+            pretty_print_alternative(condition, consequent, alternate),
         MeaningKind::ShallowArgumentSet(index, ref value) =>
-            pretty_print_shallow_set(pool, index, value.as_ref()),
+            pretty_print_shallow_set(index, value.as_ref()),
         MeaningKind::DeepArgumentSet(depth, index, ref value) =>
-            pretty_print_deep_set(pool, depth, index, value.as_ref()),
+            pretty_print_deep_set(depth, index, value.as_ref()),
         MeaningKind::GlobalSet(index, ref value) =>
-            pretty_print_global_set(pool, index, value.as_ref()),
+            pretty_print_global_set(index, value.as_ref()),
         MeaningKind::Sequence(ref computations) =>
-            pretty_print_sequence(pool, computations),
+            pretty_print_sequence(computations),
         MeaningKind::ClosureFixed(arg_count, ref body) =>
-            pretty_print_closure_fixed(pool, arg_count, body.as_ref()),
+            pretty_print_closure_fixed(arg_count, body.as_ref()),
         MeaningKind::ProcedureCall(ref procedure, ref args) =>
-            pretty_print_procedure_call(pool, procedure.as_ref(), args.as_ref()),
+            pretty_print_procedure_call(procedure.as_ref(), args.as_ref()),
     }
 }
 
@@ -446,13 +446,8 @@ fn pretty_print_undefined() -> String {
     format!("(Undefined)")
 }
 
-fn pretty_print_constant(pool: &InternPool, value: &Value) -> String {
-    match *value {
-        Value::Boolean(value) => format!("(Constant {})", if value { "#t" } else { "#f" }),
-        Value::Character(value) => format!("(Constant #\\{})", value),
-        Value::Number(value) => format!("(Constant {})", pool.get(value)),
-        Value::String(value) => format!("(Constant \"{}\")", pool.get(value)), // TODO: escape quotes
-    }
+fn pretty_print_constant(index: usize) -> String {
+    format!("(Constant {})", index)
 }
 
 fn pretty_print_shallow_reference(index: usize) -> String {
@@ -471,50 +466,50 @@ fn pretty_print_imported_reference(index: usize) -> String {
     format!("(ImportedReference {})", index)
 }
 
-fn pretty_print_alternative(pool: &InternPool, condition: &Meaning, consequent: &Meaning,
+fn pretty_print_alternative(condition: &Meaning, consequent: &Meaning,
     alternate: &Meaning) -> String
 {
     format!("(Alternative {} {} {})",
-        pretty_print(pool, condition),
-        pretty_print(pool, consequent),
-        pretty_print(pool, alternate)
+        pretty_print(condition),
+        pretty_print(consequent),
+        pretty_print(alternate)
     )
 }
 
-fn pretty_print_shallow_set(pool: &InternPool, index: usize, value: &Meaning) -> String {
-    format!("(ShallowArgumentSet {} {})", index, pretty_print(pool, value))
+fn pretty_print_shallow_set(index: usize, value: &Meaning) -> String {
+    format!("(ShallowArgumentSet {} {})", index, pretty_print(value))
 }
 
-fn pretty_print_deep_set(pool: &InternPool, depth: usize, index: usize, value: &Meaning) -> String {
-    format!("(DeepArgumentSet {} {} {})", depth, index, pretty_print(pool, value))
+fn pretty_print_deep_set(depth: usize, index: usize, value: &Meaning) -> String {
+    format!("(DeepArgumentSet {} {} {})", depth, index, pretty_print(value))
 }
 
-fn pretty_print_global_set(pool: &InternPool, index: usize, value: &Meaning) -> String {
-    format!("(GlobalSet {} {})", index, pretty_print(pool, value))
+fn pretty_print_global_set(index: usize, value: &Meaning) -> String {
+    format!("(GlobalSet {} {})", index, pretty_print(value))
 }
 
-fn pretty_print_sequence(pool: &InternPool, computations: &[Meaning]) -> String {
+fn pretty_print_sequence(computations: &[Meaning]) -> String {
     let mut s = String::new();
     s.push_str("(Sequence");
     for c in computations {
         s.push_str(" ");
-        s.push_str(&pretty_print(pool, c));
+        s.push_str(&pretty_print(c));
     }
     s.push_str(")");
     return s;
 }
 
-fn pretty_print_closure_fixed(pool: &InternPool, args_count: usize, body: &Meaning) -> String {
-    format!("(ClosureFixed {} {})", args_count, pretty_print(pool, body))
+fn pretty_print_closure_fixed(args_count: usize, body: &Meaning) -> String {
+    format!("(ClosureFixed {} {})", args_count, pretty_print(body))
 }
 
-fn pretty_print_procedure_call(pool: &InternPool, procedure: &Meaning, args: &[Meaning]) -> String {
+fn pretty_print_procedure_call(procedure: &Meaning, args: &[Meaning]) -> String {
     let mut s = String::new();
     s.push_str("(ProcedureCall ");
-    s.push_str(&pretty_print(pool, procedure));
+    s.push_str(&pretty_print(procedure));
     for a in args {
         s.push_str(" ");
-        s.push_str(&pretty_print(pool, a));
+        s.push_str(&pretty_print(a));
     }
     s.push_str(")");
     return s;

--- a/src/libeval/tests/meaning.rs
+++ b/src/libeval/tests/meaning.rs
@@ -1,0 +1,116 @@
+// Copyright (c) 2017, Sabre developers
+//
+// Licensed under the Apache License, Version 2.0 (see LICENSE.Apache in the
+// root directory) or MIT license (see LICENSE.MIT in the root directory),
+// at your option. This file may be copied, distributed, and modified only
+// in accordance with the terms specified by the chosen license.
+
+//! Expression treater test suite.
+//!
+//! This verifies that the basic semantics of Scheme is handled as expected.
+
+extern crate eval;
+extern crate locus;
+extern crate reader;
+
+use eval::meaning::{meaning, Meaning, MeaningKind};
+
+// - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+// Tested expanders and environments
+
+use eval::expanders::{Expander, ExpanderStack, BasicExpander, ApplicationExpander,
+    QuoteExpander, BeginExpander, IfExpander, SetExpander, LambdaExpander};
+use eval::meaning::{Environment};
+use locus::diagnostics::{Handler};
+use reader::intern_pool::{InternPool};
+
+fn standard_scheme<'a>(pool: &'a InternPool, handler: &'a Handler) -> Box<Expander +'a> {
+    Box::new(
+        ExpanderStack::new(Box::new(BasicExpander::new(handler)))
+            .push(Box::new(ApplicationExpander::new(handler)))
+            .push(Box::new( QuoteExpander::new(pool.intern("quote"),  handler)))
+            .push(Box::new( BeginExpander::new(pool.intern("begin"),  handler)))
+            .push(Box::new(    IfExpander::new(pool.intern("if"),     handler)))
+            .push(Box::new(   SetExpander::new(pool.intern("set"),    handler)))
+            .push(Box::new(LambdaExpander::new(pool.intern("lambda"), handler)))
+    )
+}
+
+fn basic_scheme_environment() -> Box<Environment> {
+    unimplemented!()
+}
+
+// - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+// Test helpers
+
+use reader::datum::{ScannedDatum};
+use reader::lexer::{StringScanner};
+use reader::parser::{Parser};
+use eval::expanders::{ExpansionResult};
+use eval::expression::{Expression};
+
+/// TODO
+fn check(input: &str, output: &str) {
+    let pool = InternPool::new();
+
+    let datum = parse(&pool, input);
+    let expression = expand(&pool, &datum);
+    let meaning = treat(&expression);
+
+    assert_eq!(trim_space(&pretty_print(&meaning)), trim_space(output));
+}
+
+fn parse(pool: &InternPool, input: &str) -> ScannedDatum {
+    use locus::utils::collect_diagnostics;
+
+    let (datum, parsing_diagnostics) = collect_diagnostics(|handler| {
+        let scanner = Box::new(StringScanner::new(input, handler, pool));
+        let mut parser = Parser::new(scanner, pool, handler);
+
+        let mut all_data = parser.parse_all_data();
+
+        assert!(parser.parse_all_data().is_empty(), "parser did not consume the whole stream");
+        assert!(all_data.len() == 1, "input must describe exactly one datum");
+
+        return all_data.pop().unwrap();
+    });
+
+    assert!(parsing_diagnostics.is_empty(), "parsing produced diagnostics");
+
+    return datum;
+}
+
+fn expand(pool: &InternPool, datum: &ScannedDatum) -> Expression {
+    use locus::utils::collect_diagnostics;
+
+    let (expansion_result, expansion_diagnostics) = collect_diagnostics(|handler| {
+        let expander = standard_scheme(pool, handler);
+
+        return expander.expand(&datum, expander.as_ref());
+    });
+
+    assert!(expansion_diagnostics.is_empty(), "expander produced diagnostics");
+
+    if let ExpansionResult::Some(expression) = expansion_result {
+        return expression;
+    }
+
+    panic!("expander did not produce an expression");
+}
+
+fn treat(expression: &Expression) -> Meaning {
+    let environment = basic_scheme_environment();
+
+    return meaning(expression, environment.as_ref());
+}
+
+// - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+// Pretty-printing meanings
+
+fn pretty_print(meaning: &Meaning) -> String {
+    unimplemented!()
+}
+
+fn trim_space(sexpr: &str) -> String {
+    unimplemented!()
+}

--- a/src/libeval/tests/meaning.rs
+++ b/src/libeval/tests/meaning.rs
@@ -147,6 +147,21 @@ fn assignment_global() {
 }
 
 // - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+// Sequence
+
+#[test]
+fn sequence() {
+    check("(begin 1 2 3)", "(Sequence (Constant 1) (Constant 2) (Constant 3))");
+    check("(begin (begin #f #f #t) (if #f 1 2) (begin 9))",
+        "(Sequence
+            (Sequence (Constant #f) (Constant #f) (Constant #t))
+            (Alternative (Constant #f)
+                (Constant 1)
+                (Constant 2))
+            (Sequence (Constant 9)))");
+}
+
+// - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
 // Test helpers
 
 use reader::datum::{ScannedDatum};
@@ -230,6 +245,8 @@ fn pretty_print(pool: &InternPool, meaning: &Meaning) -> String {
             pretty_print_deep_set(pool, depth, index, value.as_ref()),
         MeaningKind::GlobalSet(index, ref value) =>
             pretty_print_global_set(pool, index, value.as_ref()),
+        MeaningKind::Sequence(ref computations) =>
+            pretty_print_sequence(pool, computations),
     }
 }
 
@@ -278,6 +295,17 @@ fn pretty_print_deep_set(pool: &InternPool, depth: usize, index: usize, value: &
 
 fn pretty_print_global_set(pool: &InternPool, index: usize, value: &Meaning) -> String {
     format!("(GlobalSet {} {})", index, pretty_print(pool, value))
+}
+
+fn pretty_print_sequence(pool: &InternPool, computations: &[Meaning]) -> String {
+    let mut s = String::new();
+    s.push_str("(Sequence");
+    for c in computations {
+        s.push_str(" ");
+        s.push_str(&pretty_print(pool, c));
+    }
+    s.push_str(")");
+    return s;
 }
 
 fn trim_space(sexpr: &str) -> String {

--- a/src/libeval/tests/meaning.rs
+++ b/src/libeval/tests/meaning.rs
@@ -53,6 +53,14 @@ fn literals() {
     check("\"string\"", "(Constant \"string\")");
 }
 
+#[test]
+fn quote_literals() {
+    check("'123",           "(Constant 123)");
+    check("(quote #\\!)",   "(Constant #\\!)");
+    check("'#t",            "(Constant #t)");
+    check("(quote \"\")",   "(Constant \"\")");
+}
+
 // - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
 // Test helpers
 

--- a/src/liblocus/diagnostic_kinds.rs
+++ b/src/liblocus/diagnostic_kinds.rs
@@ -136,4 +136,10 @@ pub enum DiagnosticKind {
 
     /// Expander has encountered an invalid procedure call.
     err_expand_invalid_application,
+
+    /// Semantic analysis has found an undefined variable reference.
+    err_meaning_unresolved_variable,
+
+    /// Semantic analysis has found an assignment to an imported variable.
+    err_meaning_assign_to_imported_binding,
 }


### PR DESCRIPTION
This implements a simple semantic analysis of Scheme expressions. The main goal here is to resolve all variables and prepare the intermediate representation. Further goals are gathering and interpreting all the constants used throughout the code. Here we only gather them, but do not really interpret them.

Closes #11.