### PR TITLE
kcov-based coverage tracking

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -21,7 +21,24 @@ install:
 - ./tools/install-kcov && source ~/.profile && kcov --version
 
 script:
-- cargo test --verbose --manifest-path=src/liblocus/Cargo.toml
-- cargo test --verbose --manifest-path=src/libunicode/Cargo.toml
-- cargo test --verbose --manifest-path=src/libreader/Cargo.toml
-- cargo test --verbose --manifest-path=src/libeval/Cargo.toml
+- |
+  set -e
+
+  libraries="
+    src/libeval
+    src/liblocus
+    src/libreader
+    src/libunicode
+  "
+  for library in $libraries
+  do
+      cargo test --verbose --manifest-path="$library"/Cargo.toml --no-run
+
+      for test_binary in $(find "$library"/target/debug -maxdepth 1 -type f -executable)
+      do
+          kcov --verify \
+              --coveralls-id="$TRAVIS_JOB_ID" \
+              --strip-path="$PWD" \
+              "$PWD"/kcov "$test_binary"
+      done
+  done

--- a/.travis.yml
+++ b/.travis.yml
@@ -4,6 +4,22 @@ branches:
   except:
     - /^wip\/.*$/
 
+addons:
+  apt:
+    packages:
+    - cmake
+    - curl
+    - gcc
+    - g++
+    - pkg-config
+    - binutils-dev
+    - libcurl4-openssl-dev
+    - zlib1g-dev
+    - libdw-dev
+
+install:
+- ./tools/install-kcov && source ~/.profile && kcov --version
+
 script:
 - cargo test --verbose --manifest-path=src/liblocus/Cargo.toml
 - cargo test --verbose --manifest-path=src/libunicode/Cargo.toml

--- a/README.md
+++ b/README.md
@@ -1,3 +1,5 @@
+[![Build Status](https://travis-ci.org/ilammy/sabre.svg?branch=master)](https://travis-ci.org/ilammy/sabre) [![Coverage Status](https://coveralls.io/repos/github/ilammy/sabre/badge.svg)](https://coveralls.io/github/ilammy/sabre)
+
 Sabre
 =====
 

--- a/tools/README.md
+++ b/tools/README.md
@@ -3,4 +3,5 @@ tools
 
 A collection of various supporting tools and scripts.
 
+- `install-kcov`: installs **kcov** tool for coverage reports into CI environment.
 - `unicode-tables`: generates precomputed Unicode tables from Unicode Character Database.

--- a/tools/install-kcov
+++ b/tools/install-kcov
@@ -1,0 +1,63 @@
+#!/bin/bash
+#
+# Download, build, and install "kcov" tool for coverage analysis
+#
+# Dependencies (Debian package names):
+#
+#   cmake curl gcc g++ pkg-config binutils-dev libcurl4-openssl-dev zlib1g-dev
+#   libdw-dev libiberty-dev
+#
+# "libiberty-dev" package is not allowed on Travis CI, so we download and
+# build it as well.
+
+set -eu
+
+kcov_install_prefix=~/kcov
+
+libiberty_archive=libiberty_20141014.orig.tar.xz
+libiberty_directory=libiberty-20141014
+
+kcov_archive=v34.tar.gz
+kcov_directory=kcov-34
+
+mkdir /tmp/kcov
+cd /tmp/kcov
+
+echo "[*] Getting the source code of libiberty..."
+curl --location http://http.debian.net/debian/pool/main/libi/libiberty/$libiberty_archive > libiberty.tar.xz
+tar xf libiberty.tar.xz
+
+echo "[*] Getting the source code of kcov..."
+curl --location https://github.com/SimonKagstrom/kcov/archive/$kcov_archive > kcov.tar.gz
+tar xf kcov.tar.gz
+
+echo "[*] Building libiberty..."
+mkdir /tmp/kcov/libiberty-build
+mkdir /tmp/kcov/libiberty-install
+cd /tmp/kcov/libiberty-build
+/tmp/kcov/"$libiberty_directory"/libiberty/configure \
+    --prefix=/tmp/kcov/libiberty-install \
+    --enable-install-libiberty
+make
+make install
+
+echo "[*] Building kcov..."
+mkdir /tmp/kcov/kcov-build
+mkdir "$kcov_install_prefix"
+cd /tmp/kcov/kcov-build
+cmake \
+    -DCMAKE_PREFIX_PATH=/tmp/kcov/libiberty-install \
+    -DCMAKE_INSTALL_PREFIX="$kcov_install_prefix" \
+    /tmp/kcov/"$kcov_directory"
+make
+make install
+
+echo "[*] Configuring PATH..."
+cat >> ~/.profile <<EOF
+# kcov installation
+export PATH=$kcov_install_prefix/bin:\$PATH
+EOF
+
+echo "[*] Cleaning up..."
+cd /
+rm -r /tmp/kcov


### PR DESCRIPTION
This adds **kcov** tool for tracking code coverage of the testing suite.

Adding kcov for a Rust project turned out to be a bit convoluted, but nothing _especially_ tricky. Now we get to enjoy our nearly-100% coverage reports :)

There are some lines which produce no hits for no reason, though. No idea why. Maybe because kcov expects a panic to occur where it should not or whatever. We can always safely ignore such minor issues and focus on other parts of the project.

Closes issue #4.