### PR TITLE
Mandatory spans

### DIFF
--- a/src/libeval/expanders/application.rs
+++ b/src/libeval/expanders/application.rs
@@ -20,22 +20,17 @@ use expanders::{Expander, ExpansionResult};
 ///
 /// This expander should follow the basic expander, but come before all specific expanders that
 /// recognize special forms or macros.
-pub struct ApplicationExpander<'a> {
-    /// Designated responsible for diagnostic processing.
-    diagnostic: &'a Handler,
-}
+pub struct ApplicationExpander;
 
-impl<'a> ApplicationExpander<'a> {
-    /// Make a new application expander for a given name.
-    pub fn new(handler: &Handler) -> ApplicationExpander {
-        ApplicationExpander {
-            diagnostic: handler,
-        }
+impl ApplicationExpander {
+    /// Make a new application expander.
+    pub fn new() -> ApplicationExpander {
+        ApplicationExpander
     }
 }
 
-impl<'a> Expander for ApplicationExpander<'a> {
-    fn expand(&self, datum: &ScannedDatum, environment: &Rc<Environment>, expander: &Expander) -> ExpansionResult {
+impl Expander for ApplicationExpander {
+    fn expand(&self, datum: &ScannedDatum, environment: &Rc<Environment>, diagnostic: &Handler, expander: &Expander) -> ExpansionResult {
         use expanders::utils::{is_form, expect_list_length_at_least};
 
         // Filter out anything that certainly does not look as a form.
@@ -46,10 +41,10 @@ impl<'a> Expander for ApplicationExpander<'a> {
 
         // The only valid form is (procedure args ...).
         expect_list_length_at_least(datum, dotted, values, 1,
-            &self.diagnostic, DiagnosticKind::err_expand_invalid_application);
+            diagnostic, DiagnosticKind::err_expand_invalid_application);
 
         let expressions = values[..].iter()
-            .filter_map(|datum| match expander.expand(datum, environment, expander) {
+            .filter_map(|datum| match expander.expand(datum, environment, diagnostic, expander) {
                 ExpansionResult::Some(expression) => Some(expression),
                 ExpansionResult::None => None,
                 ExpansionResult::Unknown => None,

--- a/src/libeval/expanders/application.rs
+++ b/src/libeval/expanders/application.rs
@@ -53,7 +53,7 @@ impl Expander for ApplicationExpander {
 
         return ExpansionResult::Some(Expression {
             kind: ExpressionKind::Application(expressions),
-            span: Some(datum.span),
+            span: datum.span,
             environment: environment.clone(),
         });
     }

--- a/src/libeval/expanders/basic.rs
+++ b/src/libeval/expanders/basic.rs
@@ -35,59 +35,29 @@ impl Expander for BasicExpander {
     fn expand(&self, datum: &ScannedDatum, environment: &Rc<Environment>, diagnostic: &Handler, expander: &Expander) -> ExpansionResult {
         match datum.value {
             // Simple literal data.
-            DatumValue::Boolean(value) => {
-                ExpansionResult::Some(Expression {
-                    kind: ExpressionKind::Literal(Literal::Boolean(value)),
-                    span: Some(datum.span),
-                    environment: environment.clone(),
-                })
-            }
-            DatumValue::Number(value) => {
-                ExpansionResult::Some(Expression {
-                    kind: ExpressionKind::Literal(Literal::Number(value)),
-                    span: Some(datum.span),
-                    environment: environment.clone(),
-                })
-            }
-            DatumValue::Character(value) => {
-                ExpansionResult::Some(Expression {
-                    kind: ExpressionKind::Literal(Literal::Character(value)),
-                    span: Some(datum.span),
-                    environment: environment.clone(),
-                })
-            }
-            DatumValue::String(value) => {
-                ExpansionResult::Some(Expression {
-                    kind: ExpressionKind::Literal(Literal::String(value)),
-                    span: Some(datum.span),
-                    environment: environment.clone(),
-                })
-            }
+            DatumValue::Boolean(value) =>
+                literal(datum, environment, Literal::Boolean(value)),
+            DatumValue::Number(value) =>
+                literal(datum, environment, Literal::Number(value)),
+            DatumValue::Character(value) =>
+                literal(datum, environment, Literal::Character(value)),
+            DatumValue::String(value) =>
+                literal(datum, environment, Literal::String(value)),
 
             // Bare symbols mean variable references.
             DatumValue::Symbol(name) => {
                 ExpansionResult::Some(Expression {
                     kind: ExpressionKind::Reference(name),
-                    span: Some(datum.span),
+                    span: datum.span,
                     environment: environment.clone(),
                 })
             }
 
             // Vectors and bytevectors contain literal data.
-            DatumValue::Vector(ref elements) => {
-                ExpansionResult::Some(Expression {
-                    kind: ExpressionKind::Literal(Literal::Vector(elements.clone())),
-                    span: Some(datum.span),
-                    environment: environment.clone(),
-                })
-            }
-            DatumValue::Bytevector(ref elements) => {
-                ExpansionResult::Some(Expression {
-                    kind: ExpressionKind::Literal(Literal::Bytevector(elements.clone())),
-                    span: Some(datum.span),
-                    environment: environment.clone(),
-                })
-            }
+            DatumValue::Vector(ref elements) =>
+                literal(datum, environment, Literal::Vector(elements.clone())),
+            DatumValue::Bytevector(ref elements) =>
+                literal(datum, environment, Literal::Bytevector(elements.clone())),
 
             // These are not literal data, so we ignore them.
             DatumValue::ProperList(_) => ExpansionResult::Unknown,
@@ -108,12 +78,18 @@ impl Expander for BasicExpander {
                 diagnostic.report(DiagnosticKind::err_expand_datum_label,
                     datum.span);
 
-                ExpansionResult::Some(Expression {
-                    kind: ExpressionKind::Literal(Literal::Boolean(false)),
-                    span: Some(datum.span),
-                    environment: environment.clone(),
-                })
+                literal(datum, environment, Literal::Boolean(false))
             }
         }
     }
+}
+
+fn literal(datum: &ScannedDatum, environment: &Rc<Environment>, value: Literal)
+    -> ExpansionResult
+{
+    ExpansionResult::Some(Expression {
+        kind: ExpressionKind::Literal(value),
+        span: datum.span,
+        environment: environment.clone(),
+    })
 }

--- a/src/libeval/expanders/basic.rs
+++ b/src/libeval/expanders/basic.rs
@@ -22,22 +22,17 @@ use expanders::{Expander, ExpansionResult};
 /// in programs. Ignore all non-atomic forms.
 ///
 /// This expander should be the root expander of the macro expander stack.
-pub struct BasicExpander<'a> {
-    /// Designated responsible for diagnostic processing.
-    diagnostic: &'a Handler,
-}
+pub struct BasicExpander;
 
-impl<'a> BasicExpander<'a> {
+impl BasicExpander {
     /// Make a new fixed expander.
-    pub fn new(handler: &Handler) -> BasicExpander {
-        BasicExpander {
-            diagnostic: handler,
-        }
+    pub fn new() -> BasicExpander {
+        BasicExpander
     }
 }
 
-impl<'a> Expander for BasicExpander<'a> {
-    fn expand(&self, datum: &ScannedDatum, environment: &Rc<Environment>, expander: &Expander) -> ExpansionResult {
+impl Expander for BasicExpander {
+    fn expand(&self, datum: &ScannedDatum, environment: &Rc<Environment>, diagnostic: &Handler, expander: &Expander) -> ExpansionResult {
         match datum.value {
             // Simple literal data.
             DatumValue::Boolean(value) => {
@@ -101,16 +96,16 @@ impl<'a> Expander for BasicExpander<'a> {
             // Labeled data cannot be used in programs, only in literal quoted data.
             // Report the error and assume the label never existed, reinvoking the expander.
             DatumValue::LabeledDatum(_, ref labeled_datum) => {
-                self.diagnostic.report(DiagnosticKind::err_expand_datum_label,
+                diagnostic.report(DiagnosticKind::err_expand_datum_label,
                     Span::new(datum.span.from, labeled_datum.span.from));
 
-                expander.expand(&labeled_datum, environment, expander)
+                expander.expand(&labeled_datum, environment, diagnostic, expander)
             }
 
             // Datum labels cannot be used in programs, only in literal quoted data.
             // Report the error and use some placeholder value instead.
             DatumValue::LabelReference(_) => {
-                self.diagnostic.report(DiagnosticKind::err_expand_datum_label,
+                diagnostic.report(DiagnosticKind::err_expand_datum_label,
                     datum.span);
 
                 ExpansionResult::Some(Expression {

--- a/src/libeval/expanders/begin.rs
+++ b/src/libeval/expanders/begin.rs
@@ -57,7 +57,7 @@ impl Expander for BeginExpander {
 
         return ExpansionResult::Some(Expression {
             kind: ExpressionKind::Sequence(expressions),
-            span: Some(datum.span),
+            span: datum.span,
             environment: environment.clone(),
         });
     }

--- a/src/libeval/expanders/expander.rs
+++ b/src/libeval/expanders/expander.rs
@@ -9,6 +9,7 @@
 
 use std::rc::{Rc};
 
+use locus::diagnostics::{Handler};
 use reader::datum::{ScannedDatum};
 
 use environment::{Environment};
@@ -20,7 +21,8 @@ pub trait Expander {
     ///
     /// Normally the provided expander will be the same as `self`, but syntactic binding forms
     /// may replace it with an extended version.
-    fn expand(&self, datum: &ScannedDatum, environment: &Rc<Environment>, expand: &Expander) -> ExpansionResult;
+    fn expand(&self, datum: &ScannedDatum, environment: &Rc<Environment>, diagnosic: &Handler,
+        expand: &Expander) -> ExpansionResult;
 }
 
 /// Result of macro expansion.

--- a/src/libeval/expanders/if_expander.rs
+++ b/src/libeval/expanders/if_expander.rs
@@ -34,7 +34,7 @@ impl IfExpander {
 
 impl Expander for IfExpander {
     fn expand(&self, datum: &ScannedDatum, environment: &Rc<Environment>, diagnostic: &Handler, expander: &Expander) -> ExpansionResult {
-        use expanders::utils::{is_named_form, expect_list_length_fixed};
+        use expanders::utils::{is_named_form, expect_list_length_fixed, missing_last_span};
 
         // Filter out anything that certainly does not look as a if form.
         let (dotted, values) = match is_named_form(datum, self.name) {
@@ -42,31 +42,33 @@ impl Expander for IfExpander {
             None => { return ExpansionResult::Unknown; }
         };
 
+        assert!(values.len() >= 1);
+
         // The only valid form is (if condition consequence alternative).
         expect_list_length_fixed(datum, dotted, values, 4,
             diagnostic, DiagnosticKind::err_expand_invalid_if);
 
         // Recover from errors by using #f as placeholder values.
-        let expand_or_recover = |datum| {
-            if let Some(datum) = datum {
-                let result = expander.expand(datum, environment, diagnostic, expander);
+        let expand_or_recover = |index| {
+            if let Some(term) = values.get(index) {
+                let result = expander.expand(term, environment, diagnostic, expander);
                 if let ExpansionResult::Some(expression) = result {
                     return expression;
                 }
             }
             return Expression {
                 kind: ExpressionKind::Literal(Literal::Boolean(false)),
-                span: None,
+                span: missing_last_span(datum),
                 environment: environment.clone(),
             };
         };
-        let condition   = Box::new(expand_or_recover(values.get(1)));
-        let consequence = Box::new(expand_or_recover(values.get(2)));
-        let alternative = Box::new(expand_or_recover(values.get(3)));
+        let condition   = Box::new(expand_or_recover(1));
+        let consequence = Box::new(expand_or_recover(2));
+        let alternative = Box::new(expand_or_recover(3));
 
         return ExpansionResult::Some(Expression {
             kind: ExpressionKind::Alternative(condition, consequence, alternative),
-            span: Some(datum.span),
+            span: datum.span,
             environment: environment.clone(),
         });
     }

--- a/src/libeval/expanders/lambda.rs
+++ b/src/libeval/expanders/lambda.rs
@@ -18,26 +18,22 @@ use expression::{Expression, ExpressionKind, Variable, Arguments};
 use expanders::{Expander, ExpansionResult};
 
 /// Expand `lambda` special forms into abstractions.
-pub struct LambdaExpander<'a> {
+pub struct LambdaExpander {
     /// Recognized `lambda` atom.
     name: Atom,
-
-    /// Designated responsible for diagnostic processing.
-    diagnostic: &'a Handler,
 }
 
-impl<'a> LambdaExpander<'a> {
+impl LambdaExpander {
     /// Make a new `lambda` expander for a given name.
-    pub fn new(name: Atom, handler: &Handler) -> LambdaExpander {
+    pub fn new(name: Atom) -> LambdaExpander {
         LambdaExpander {
             name: name,
-            diagnostic: handler,
         }
     }
 }
 
-impl<'a> Expander for LambdaExpander<'a> {
-    fn expand(&self, datum: &ScannedDatum, environment: &Rc<Environment>, expander: &Expander) -> ExpansionResult {
+impl Expander for LambdaExpander {
+    fn expand(&self, datum: &ScannedDatum, environment: &Rc<Environment>, diagnostic: &Handler, expander: &Expander) -> ExpansionResult {
         use expanders::utils::{is_named_form, expect_list_length_at_least};
 
         // Filter out anything that certainly does not look as a lambda form.
@@ -48,18 +44,18 @@ impl<'a> Expander for LambdaExpander<'a> {
 
         // The only valid form is (lambda (variable...) body1 body2...).
         expect_list_length_at_least(datum, dotted, values, 3,
-            &self.diagnostic, DiagnosticKind::err_expand_invalid_lambda);
+            diagnostic, DiagnosticKind::err_expand_invalid_lambda);
 
         // The first element describes the abstraction's arguments. They form a new local
         // environment for the procedure body.
-        let arguments = self.expand_arguments(values.get(1));
+        let arguments = expand_arguments(values.get(1), diagnostic);
         let new_environment = new_local_environment(&arguments, environment);
 
         // All other elements (except for the first two) are the procedure body.
         // Expand them sequentially, as in the begin form.
         let expressions = values.iter()
             .skip(2)
-            .filter_map(|datum| match expander.expand(datum, &new_environment, expander) {
+            .filter_map(|datum| match expander.expand(datum, &new_environment, diagnostic, expander) {
                 ExpansionResult::Some(expression) => Some(expression),
                 ExpansionResult::None => None,
                 ExpansionResult::Unknown => None,
@@ -74,80 +70,78 @@ impl<'a> Expander for LambdaExpander<'a> {
     }
 }
 
-impl<'a> LambdaExpander<'a> {
-    /// Expand the argument list.
-    ///
-    /// Simply ignore non-variables in the list, or fall back to empty argument list in case the
-    /// problem is really severe.
-    fn expand_arguments(&self, datum: Option<&ScannedDatum>) -> Arguments {
-        if let Some(arguments) = self.expect_argument_list(datum) {
-            let raw_variables: Vec<Variable> = arguments.iter()
-                .filter_map(|argument| {
-                    if let DatumValue::Symbol(name) = argument.value {
-                        Some(Variable { name: name, span: Some(argument.span) })
-                    } else {
-                        self.diagnostic.report(DiagnosticKind::err_expand_invalid_lambda,
-                            argument.span);
-                        None
-                    }
-                })
-                .collect();
+/// Expand the argument list.
+///
+/// Simply ignore non-variables in the list, or fall back to empty argument list in case the
+/// problem is really severe.
+fn expand_arguments(datum: Option<&ScannedDatum>, diagnostic: &Handler) -> Arguments {
+    if let Some(arguments) = expect_argument_list(datum, diagnostic) {
+        let raw_variables: Vec<Variable> = arguments.iter()
+            .filter_map(|argument| {
+                if let DatumValue::Symbol(name) = argument.value {
+                    Some(Variable { name: name, span: Some(argument.span) })
+                } else {
+                    diagnostic.report(DiagnosticKind::err_expand_invalid_lambda,
+                        argument.span);
+                    None
+                }
+            })
+            .collect();
 
-            let variables = self.deduplicate_variables(raw_variables);
+        let variables = deduplicate_variables(raw_variables, diagnostic);
 
-            return Arguments::Fixed(variables);
-        }
-        return Arguments::Fixed(vec![]);
+        return Arguments::Fixed(variables);
     }
+    return Arguments::Fixed(vec![]);
+}
 
-    /// Extract argument list from the datum (if it really looks like an argument list).
-    fn expect_argument_list<'b>(&self, datum: Option<&'b ScannedDatum>)
-        -> Option<&'b [ScannedDatum]>
-    {
-        if let Some(datum) = datum {
-            match datum.value {
-                DatumValue::ProperList(ref data) => {
-                    return Some(&data);
-                }
-                DatumValue::DottedList(ref data) => {
-                    // Currently we do not support &rest arguments, so we unify them into
-                    // fixed argument list and produce a diagnostic.
-                    assert!(data.len() >= 2);
-                    let last = data.len() - 1;
-                    self.diagnostic.report(DiagnosticKind::err_expand_invalid_lambda,
-                        Span::new(data[last - 1].span.to, data[last].span.from));
+/// Extract argument list from the datum (if it really looks like an argument list).
+fn expect_argument_list<'b>(datum: Option<&'b ScannedDatum>, diagnostic: &Handler)
+    -> Option<&'b [ScannedDatum]>
+{
+    if let Some(datum) = datum {
+        match datum.value {
+            DatumValue::ProperList(ref data) => {
+                return Some(&data);
+            }
+            DatumValue::DottedList(ref data) => {
+                // Currently we do not support &rest arguments, so we unify them into
+                // fixed argument list and produce a diagnostic.
+                assert!(data.len() >= 2);
+                let last = data.len() - 1;
+                diagnostic.report(DiagnosticKind::err_expand_invalid_lambda,
+                    Span::new(data[last - 1].span.to, data[last].span.from));
 
-                    return Some(&data);
-                }
-                _ => {
-                    self.diagnostic.report(DiagnosticKind::err_expand_invalid_lambda,
-                        datum.span);
-                }
+                return Some(&data);
+            }
+            _ => {
+                diagnostic.report(DiagnosticKind::err_expand_invalid_lambda,
+                    datum.span);
             }
         }
-        return None;
     }
+    return None;
+}
 
-    /// Check that arguments are not duplicated, report and remove duplicates.
-    fn deduplicate_variables(&self, raw_variables: Vec<Variable>) -> Vec<Variable> {
-        let mut variables: Vec<Variable> = Vec::with_capacity(raw_variables.len());
+/// Check that arguments are not duplicated, report and remove duplicates.
+fn deduplicate_variables(raw_variables: Vec<Variable>, diagnostic: &Handler) -> Vec<Variable> {
+    let mut variables: Vec<Variable> = Vec::with_capacity(raw_variables.len());
 
-        // Argument lists should be short, so this O(n^2) algorithm is okay.
-        'next_variable:
-        for variable in raw_variables {
-            for previous in &variables {
-                if variable.name == previous.name {
-                    self.diagnostic.report(DiagnosticKind::err_expand_invalid_lambda,
-                        variable.span.expect("all lambda args have spans"));
+    // Argument lists should be short, so this O(n^2) algorithm is okay.
+    'next_variable:
+    for variable in raw_variables {
+        for previous in &variables {
+            if variable.name == previous.name {
+                diagnostic.report(DiagnosticKind::err_expand_invalid_lambda,
+                    variable.span.expect("all lambda args have spans"));
 
-                    continue 'next_variable;
-                }
+                continue 'next_variable;
             }
-            variables.push(variable);
         }
-
-        return variables;
+        variables.push(variable);
     }
+
+    return variables;
 }
 
 /// Extend the parent environment with new variables based on the argument list of a lambda form.

--- a/src/libeval/expanders/lambda.rs
+++ b/src/libeval/expanders/lambda.rs
@@ -64,7 +64,7 @@ impl Expander for LambdaExpander {
 
         return ExpansionResult::Some(Expression {
             kind: ExpressionKind::Abstraction(arguments, expressions),
-            span: Some(datum.span),
+            span: datum.span,
             environment: environment.clone(), // note that this is *not* the new environment
         });
     }

--- a/src/libeval/expanders/quote.rs
+++ b/src/libeval/expanders/quote.rs
@@ -18,26 +18,22 @@ use expression::{Expression, ExpressionKind};
 use expanders::{Expander, ExpansionResult};
 
 /// Expand `quote` special forms into quotations.
-pub struct QuoteExpander<'a> {
+pub struct QuoteExpander {
     /// Recognized `quote` atom.
     name: Atom,
-
-    /// Designated responsible for diagnostic processing.
-    diagnostic: &'a Handler,
 }
 
-impl<'a> QuoteExpander<'a> {
+impl QuoteExpander {
     /// Make a new `quote` expander for a given name.
-    pub fn new(name: Atom, handler: &Handler) -> QuoteExpander {
+    pub fn new(name: Atom) -> QuoteExpander {
         QuoteExpander {
             name: name,
-            diagnostic: handler,
         }
     }
 }
 
-impl<'a> Expander for QuoteExpander<'a> {
-    fn expand(&self, datum: &ScannedDatum, environment: &Rc<Environment>, _expand: &Expander) -> ExpansionResult {
+impl Expander for QuoteExpander {
+    fn expand(&self, datum: &ScannedDatum, environment: &Rc<Environment>, diagnostic: &Handler, _expand: &Expander) -> ExpansionResult {
         use expanders::utils::{is_named_form, expect_list_length_fixed};
 
         // Filter out anything that certainly does not look as a quote form.
@@ -48,7 +44,7 @@ impl<'a> Expander for QuoteExpander<'a> {
 
         // The only valid form is (quote datum).
         expect_list_length_fixed(datum, dotted, values, 2,
-            &self.diagnostic, DiagnosticKind::err_expand_invalid_quote);
+            diagnostic, DiagnosticKind::err_expand_invalid_quote);
 
         // Well, even in error cases we can recover. If there are values then return the last one
         // (consistent with `begin`). Otherwise pull an `#f` out of thin air as a placeholder.

--- a/src/libeval/expanders/quote.rs
+++ b/src/libeval/expanders/quote.rs
@@ -59,7 +59,7 @@ impl Expander for QuoteExpander {
 
         return ExpansionResult::Some(Expression {
             kind: ExpressionKind::Quotation(result),
-            span: Some(datum.span),
+            span: datum.span,
             environment: environment.clone(),
         });
     }

--- a/src/libeval/expanders/stack.rs
+++ b/src/libeval/expanders/stack.rs
@@ -9,6 +9,7 @@
 
 use std::rc::{Rc};
 
+use locus::diagnostics::{Handler};
 use reader::datum::{ScannedDatum};
 
 use environment::{Environment};
@@ -22,17 +23,17 @@ use expanders::{Expander, ExpansionResult};
 /// The stack is an expander as well. It tries the embedded expanders sequentially in LIFO order
 /// until one of them fails or produces a value. The stack returns `Unknown` value only when all
 /// subexpanders do not know what to do with the datum.
-pub struct ExpanderStack<'a> {
+pub struct ExpanderStack {
     /// The current expander.
-    head: Box<Expander + 'a>,
+    head: Box<Expander>,
 
     /// The rest of the expanders.
-    tail: Option<Box<ExpanderStack<'a>>>,
+    tail: Option<Box<ExpanderStack>>,
 }
 
-impl<'a> ExpanderStack<'a> {
+impl ExpanderStack {
     /// Create a new expander stack with a given expander.
-    pub fn new(base: Box<Expander + 'a>) -> ExpanderStack<'a> {
+    pub fn new(base: Box<Expander>) -> ExpanderStack {
         ExpanderStack {
             head: base,
             tail: None,
@@ -40,7 +41,7 @@ impl<'a> ExpanderStack<'a> {
     }
 
     /// Push a new expander into the stack.
-    pub fn push(self, head: Box<Expander + 'a>) -> ExpanderStack<'a> {
+    pub fn push(self, head: Box<Expander>) -> ExpanderStack {
         ExpanderStack {
             head: head,
             tail: Some(Box::new(self)),
@@ -51,16 +52,16 @@ impl<'a> ExpanderStack<'a> {
     ///
     /// Returns None if that expander was the last one and you have messed up (as this should not
     /// happen if the environments are balanced).
-    pub fn pop(self) -> Option<ExpanderStack<'a>> {
+    pub fn pop(self) -> Option<ExpanderStack> {
         self.tail.map(|v| *v)
     }
 }
 
-impl<'a> Expander for ExpanderStack<'a> {
-    fn expand(&self, datum: &ScannedDatum, environment: &Rc<Environment>, expander: &Expander) -> ExpansionResult {
+impl Expander for ExpanderStack {
+    fn expand(&self, datum: &ScannedDatum, environment: &Rc<Environment>, diagnostic: &Handler, expander: &Expander) -> ExpansionResult {
         let mut current = self.head.as_ref();
         loop {
-            let result = current.expand(datum, environment, expander);
+            let result = current.expand(datum, environment, diagnostic, expander);
 
             if let ExpansionResult::Unknown = result {
                 if let Some(ref next) = self.tail {

--- a/src/libeval/expression.rs
+++ b/src/libeval/expression.rs
@@ -24,8 +24,8 @@ pub struct Expression {
     /// Environment available at this expression.
     pub environment: Rc<Environment>,
 
-    /// Closest known source of the expression.
-    pub span: Option<Span>,
+    /// Source of the expression.
+    pub span: Span,
 }
 
 /// Kind of an expression.

--- a/src/libeval/tests/expander.rs
+++ b/src/libeval/tests/expander.rs
@@ -18,7 +18,7 @@ use std::rc::{Rc};
 use eval::environment::{Environment};
 use eval::expanders::{Expander, ExpansionResult, ExpanderStack, BasicExpander,
     ApplicationExpander, QuoteExpander, BeginExpander, IfExpander, SetExpander, LambdaExpander};
-use locus::diagnostics::{Handler, DiagnosticKind};
+use locus::diagnostics::{DiagnosticKind};
 use reader::intern_pool::{InternPool};
 
 // - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
@@ -45,14 +45,14 @@ impl Default for SchemeBase {
 }
 
 impl SchemeBase {
-    fn make<'a>(&self, pool: &InternPool, handler: &'a Handler) -> ExpanderStack<'a> {
-        ExpanderStack::new(Box::new(BasicExpander::new(handler)))
-            .push(Box::new(ApplicationExpander::new(handler)))
-            .push(Box::new( QuoteExpander::new(pool.intern(self.quote),  handler)))
-            .push(Box::new( BeginExpander::new(pool.intern(self.begin),  handler)))
-            .push(Box::new(    IfExpander::new(pool.intern(self.if_),    handler)))
-            .push(Box::new(   SetExpander::new(pool.intern(self.set),    handler)))
-            .push(Box::new(LambdaExpander::new(pool.intern(self.lambda), handler)))
+    fn make(&self, pool: &InternPool) -> ExpanderStack {
+        ExpanderStack::new(Box::new(BasicExpander::new()))
+            .push(Box::new(ApplicationExpander::new()))
+            .push(Box::new( QuoteExpander::new(pool.intern(self.quote))))
+            .push(Box::new( BeginExpander::new(pool.intern(self.begin))))
+            .push(Box::new(    IfExpander::new(pool.intern(self.if_))))
+            .push(Box::new(   SetExpander::new(pool.intern(self.set))))
+            .push(Box::new(LambdaExpander::new(pool.intern(self.lambda))))
     }
 }
 
@@ -793,9 +793,9 @@ fn check(expander_factory: &SchemeBase, input: &str, expected_result: &str, expe
     let (expand_result, expand_diagnostics) = collect_diagnostics(|handler| {
         let environment = basic_scheme_environment(&pool);
 
-        let expander = expander_factory.make(&pool, handler);
+        let expander = expander_factory.make(&pool);
 
-        expander.expand(&datum, &environment, &expander)
+        expander.expand(&datum, &environment, &handler, &expander)
     });
 
     let expand_result = match expand_result {

--- a/src/libeval/tests/expander.rs
+++ b/src/libeval/tests/expander.rs
@@ -749,7 +749,7 @@ impl TestCase {
     fn diagnostic(mut self, from: usize, to: usize, kind: DiagnosticKind) -> Self {
         self.expected_diagnostics.push(Diagnostic {
             kind: kind,
-            loc: Some(Span::new(from, to))
+            span: Span::new(from, to),
         });
         self
     }

--- a/src/libeval/tests/meaning.rs
+++ b/src/libeval/tests/meaning.rs
@@ -24,18 +24,18 @@ use eval::expanders::{Expander, ExpanderStack, BasicExpander, ApplicationExpande
     QuoteExpander, BeginExpander, IfExpander, SetExpander, LambdaExpander};
 use eval::expression::{Variable};
 use eval::environment::{Environment};
-use locus::diagnostics::{DiagnosticKind, Handler};
+use locus::diagnostics::{DiagnosticKind};
 use reader::intern_pool::{InternPool};
 
-fn standard_scheme<'a>(pool: &'a InternPool, handler: &'a Handler) -> Box<Expander +'a> {
+fn standard_scheme(pool: &InternPool) -> Box<Expander> {
     Box::new(
-        ExpanderStack::new(Box::new(BasicExpander::new(handler)))
-            .push(Box::new(ApplicationExpander::new(handler)))
-            .push(Box::new( QuoteExpander::new(pool.intern("quote"),  handler)))
-            .push(Box::new( BeginExpander::new(pool.intern("begin"),  handler)))
-            .push(Box::new(    IfExpander::new(pool.intern("if"),     handler)))
-            .push(Box::new(   SetExpander::new(pool.intern("set!"),   handler)))
-            .push(Box::new(LambdaExpander::new(pool.intern("lambda"), handler)))
+        ExpanderStack::new(Box::new(BasicExpander::new()))
+            .push(Box::new(ApplicationExpander::new()))
+            .push(Box::new( QuoteExpander::new(pool.intern("quote"))))
+            .push(Box::new( BeginExpander::new(pool.intern("begin"))))
+            .push(Box::new(    IfExpander::new(pool.intern("if"))))
+            .push(Box::new(   SetExpander::new(pool.intern("set!"))))
+            .push(Box::new(LambdaExpander::new(pool.intern("lambda"))))
     )
 }
 
@@ -456,10 +456,10 @@ fn expand(pool: &InternPool, data: &[ScannedDatum]) -> Vec<Expression> {
 
     let (expansion_result, expansion_diagnostics) = collect_diagnostics(|handler| {
         let environment = basic_scheme_environment(pool);
-        let expander = standard_scheme(pool, handler);
+        let expander = standard_scheme(pool);
 
         return data.iter()
-            .map(|d| expander.expand(d, &environment, expander.as_ref()))
+            .map(|d| expander.expand(d, &environment, &handler, expander.as_ref()))
             .map(|e| match e {
                 ExpansionResult::Some(e) => e,
                 _ => panic!("expander did not produce an expression"),

--- a/src/libeval/tests/meaning.rs
+++ b/src/libeval/tests/meaning.rs
@@ -56,6 +56,25 @@ fn basic_scheme_environment(pool: &InternPool) -> Rc<Environment> {
 }
 
 // - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+// Edge cases
+
+#[test]
+fn empty_file() {
+    TestCase::new()
+        .input("")
+        .meaning("(Sequence)")
+        .check();
+}
+
+#[test]
+fn only_comments() {
+    TestCase::new()
+        .input("; test test")
+        .meaning("(Sequence)")
+        .check();
+}
+
+// - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
 // Constants
 
 #[test]

--- a/src/libeval/tests/meaning.rs
+++ b/src/libeval/tests/meaning.rs
@@ -397,7 +397,7 @@ impl TestCase {
     fn diagnostic(mut self, from: usize, to: usize, kind: DiagnosticKind) -> Self {
         self.expected_diagnostics.push(Diagnostic {
             kind: kind,
-            loc: Some(Span::new(from, to))
+            span: Span::new(from, to),
         });
         self
     }

--- a/src/liblocus/diagnostics.rs
+++ b/src/liblocus/diagnostics.rs
@@ -46,8 +46,8 @@ pub struct Diagnostic {
     /// The kind of a diagnostic.
     pub kind: DiagnosticKind,
 
-    /// Optional primary location of the offending code.
-    pub loc: Option<Span>,
+    /// Location of the offending code.
+    pub span: Span,
 }
 
 /// Diagnostic reporter interface.
@@ -59,7 +59,7 @@ pub trait Reporter {
     fn report(&mut self, diagnostic: Diagnostic);
 }
 
-/// Convenience wrapper for reporting diagnostics with known spans.
+/// Convenience wrapper for reporting diagnostics.
 pub struct Handler {
     /// Internal reporter implementation.
     reporter: RefCell<Box<Reporter>>,
@@ -75,9 +75,6 @@ impl Handler {
 
     /// Immediately report a single diagnostic.
     pub fn report(&self, kind: DiagnosticKind, span: Span) {
-        self.reporter.borrow_mut().report(Diagnostic {
-            kind: kind,
-            loc: Some(span),
-        });
+        self.reporter.borrow_mut().report(Diagnostic { kind, span });
     }
 }

--- a/src/liblocus/utils.rs
+++ b/src/liblocus/utils.rs
@@ -72,11 +72,11 @@ mod tests {
         assert_eq!(diagnostics, vec![
             Diagnostic {
                 kind: DiagnosticKind::fatal_lexer_unterminated_comment,
-                loc: Some(Span::new(0, 1)),
+                span: Span::new(0, 1),
             },
             Diagnostic {
                 kind: DiagnosticKind::err_parser_misplaced_dot,
-                loc: Some(Span::new(34, 51)),
+                span: Span::new(34, 51),
             },
         ]);
     }

--- a/src/libreader/tests/lexer.rs
+++ b/src/libreader/tests/lexer.rs
@@ -4003,8 +4003,8 @@ fn compute_expected_results(test_slices: &[ScannerTestSlice]) -> ScannerTestResu
 
             diagnostics.push(Diagnostic {
                 kind: diagnostic.kind.clone(),
-                loc: Some(Span::new(byte_offset + diagnostic.from,
-                                    byte_offset + diagnostic.to)),
+                span: Span::new(byte_offset + diagnostic.from,
+                                byte_offset + diagnostic.to),
             });
         }
 
@@ -4097,18 +4097,12 @@ fn print_token(token: &ScannedToken, buf: &str, pool: &InternPool) -> String {
 
 /// Pretty-print a diagnostic in diffs.
 fn print_diagnostic(diagnostic: &Diagnostic, buf: &str) -> String {
-    if let Some(ref loc) = diagnostic.loc {
-        format!("{diagnostic} @ [{from}, {to}] = {slice:?}",
-            diagnostic = pretty_print_diagnostic(diagnostic),
-            from       = loc.from,
-            to         = loc.to,
-            slice      = &buf[loc.from..loc.to],
-        )
-    } else {
-        format!("{diagnostic} @ nowhere",
-            diagnostic = pretty_print_diagnostic(diagnostic),
-        )
-    }
+    format!("{diagnostic} @ [{from}, {to}] = {slice:?}",
+        diagnostic = pretty_print_diagnostic(diagnostic),
+        from       = diagnostic.span.from,
+        to         = diagnostic.span.to,
+        slice      = &buf[diagnostic.span.from..diagnostic.span.to],
+    )
 }
 
 /// Pretty-print a token.

--- a/src/libreader/tests/parser.rs
+++ b/src/libreader/tests/parser.rs
@@ -1108,7 +1108,7 @@ impl TestCase {
     fn diagnostic(mut self, from: usize, to: usize, kind: DiagnosticKind) -> Self {
         self.expected_diagnostics.push(Diagnostic {
             kind: kind,
-            loc: Some(Span::new(from, to))
+            span: Span::new(from, to)
         });
         self
     }


### PR DESCRIPTION
This is a preparation for new macro expander and semantic analyzer. It should simplify the new implementation which will keep macro expanders in environments. (See issue #13.)

Previously we have had some spans marked as optional. The idea here was that if the expressions come from macro expansion then they cannot have spans (as they come from expressions 'invented' by macro expander). However, a correct implementation should track at least the source of the expression (the first macro). An ideal one would track the whole macro expansion chain.

Currently we do not implement any macros, so we do not really need this. Later we may replace `Span` with some `NonEmptyVec<Span>` or something. But it certainly does not need to be an `Option`.