### PR TITLE
Introduce Undefined expression

### DIFF
--- a/src/libeval/expanders/begin.rs
+++ b/src/libeval/expanders/begin.rs
@@ -47,10 +47,14 @@ impl Expander for BeginExpander {
             expect_begin_form(self.name, datum, diagnostic)
             .iter()
             .map(|datum| expand(datum, environment, diagnostic))
-            .collect();
+            .collect::<Vec<_>>();
 
         return Expression {
-            kind: ExpressionKind::Sequence(expressions),
+            kind: if expressions.is_empty() {
+                ExpressionKind::Undefined
+            } else {
+                ExpressionKind::Sequence(expressions)
+            },
             span: datum.span,
             environment: environment.clone(),
         };

--- a/src/libeval/expanders/if_expander.rs
+++ b/src/libeval/expanders/if_expander.rs
@@ -14,7 +14,7 @@ use reader::datum::{ScannedDatum};
 use reader::intern_pool::{Atom};
 
 use environment::{Environment};
-use expression::{Expression, ExpressionKind, Literal};
+use expression::{Expression, ExpressionKind};
 use expand::Expander;
 
 /// Expand `if` special forms into alternatives.
@@ -49,11 +49,12 @@ impl Expander for IfExpander {
         let expand_or_recover = |term: Option<&ScannedDatum>| {
             term.map(|datum| expand(datum, environment, diagnostic))
                 .unwrap_or(Expression {
-                    kind: ExpressionKind::Literal(Literal::Boolean(false)),
+                    kind: ExpressionKind::Undefined,
                     span: missing_last_span(datum),
                     environment: environment.clone(),
                 })
         };
+
         let condition   = Box::new(expand_or_recover(terms.get(0)));
         let consequent  = Box::new(expand_or_recover(terms.get(1)));
         let alternative = Box::new(expand_or_recover(terms.get(2)));

--- a/src/libeval/expanders/quote.rs
+++ b/src/libeval/expanders/quote.rs
@@ -10,7 +10,7 @@
 use std::rc::{Rc};
 
 use locus::diagnostics::{Handler, DiagnosticKind, Span};
-use reader::datum::{ScannedDatum, DatumValue};
+use reader::datum::{ScannedDatum};
 use reader::intern_pool::{Atom};
 
 use environment::{Environment};
@@ -39,19 +39,16 @@ impl Expander for QuoteExpander {
         environment: &Rc<Environment>,
         diagnostic: &Handler,
     ) -> Expression {
-        use expanders::utils::missing_last_span;
-
         // The only valid form is (quote datum). Do not expand anything. Use the first datum
         // available or pull some placeholder out of thin air if this is a (quote) form.
         let data = expect_quote_form(self.name, datum, diagnostic);
 
-        let quoted_datum = data.first().cloned().unwrap_or_else(|| ScannedDatum {
-            value: DatumValue::Boolean(false),
-            span: missing_last_span(datum),
-        });
-
         return Expression {
-            kind: ExpressionKind::Quotation(quoted_datum),
+            kind: if let Some(quoted_datum) = data.first().cloned() {
+                ExpressionKind::Quotation(quoted_datum)
+            } else {
+                ExpressionKind::Undefined
+            },
             span: datum.span,
             environment: environment.clone(),
         };

--- a/src/libeval/expanders/set.rs
+++ b/src/libeval/expanders/set.rs
@@ -14,7 +14,7 @@ use reader::datum::{ScannedDatum, DatumValue};
 use reader::intern_pool::{Atom};
 
 use environment::{Environment};
-use expression::{Expression, ExpressionKind, Literal, Variable};
+use expression::{Expression, ExpressionKind, Variable};
 use expand::Expander;
 
 /// Expand `set!` special forms into assignments.
@@ -117,7 +117,7 @@ fn expand_new_value(
 
     term.map(|datum| expand(datum, environment, diagnostic))
         .unwrap_or(Expression {
-            kind: ExpressionKind::Literal(Literal::Boolean(false)),
+            kind: ExpressionKind::Undefined,
             span: missing_last_span(datum),
             environment: environment.clone(),
         })

--- a/src/libeval/expression.rs
+++ b/src/libeval/expression.rs
@@ -53,6 +53,9 @@ pub enum ExpressionKind {
 
     /// Procedure call.
     Application(Vec<Expression>),
+
+    /// An expression producing undefined value.
+    Undefined,
 }
 
 /// Literal value.
@@ -131,6 +134,8 @@ impl fmt::Debug for Expression {
                 try!(write!(f, ")"));
                 Ok(())
             }
+            ExpressionKind::Undefined =>
+                write!(f, "(Undefined)"),
         }
     }
 }

--- a/src/libeval/meaning.rs
+++ b/src/libeval/meaning.rs
@@ -235,6 +235,7 @@ fn meaning_expression(
                 meaning_abstraction(diagnostic, arguments, body, constants),
             ExpressionKind::Application(ref terms) =>
                 meaning_application(diagnostic, terms, constants),
+            ExpressionKind::Undefined => MeaningKind::Undefined,
         },
         span: expression.span,
     }

--- a/src/libeval/tests/expander.rs
+++ b/src/libeval/tests/expander.rs
@@ -397,7 +397,7 @@ fn set_nested() {
 fn set_forms_0() {
     TestCase::new()
         .input("(set!)")
-        .result("(Literal #f)")
+        .result("(Undefined)")
         .diagnostic(5, 5, DiagnosticKind::err_expand_invalid_set)
         .check();
 }
@@ -406,7 +406,7 @@ fn set_forms_0() {
 fn set_forms_1() {
     TestCase::new()
         .input("(set! i)")
-        .result("(Assignment i (Literal #f))")
+        .result("(Assignment i (Undefined))")
         .diagnostic(7, 7, DiagnosticKind::err_expand_invalid_set)
         .check();
 }
@@ -415,7 +415,7 @@ fn set_forms_1() {
 fn set_forms_1_dotted() {
     TestCase::new()
         .input("(set! . i)")
-        .result("(Assignment i (Literal #f))")
+        .result("(Assignment i (Undefined))")
         .diagnostic(9, 9, DiagnosticKind::err_expand_invalid_set)
         .diagnostic(5, 8, DiagnosticKind::err_expand_invalid_set)
         .check();
@@ -475,7 +475,7 @@ fn set_renaming() {
     TestCase::new()
         .input("(!!!SUMMER-ASSIGNMENT!!!)")
         .keywords(MagicKeywords { set: "!!!SUMMER-ASSIGNMENT!!!", ..Default::default() })
-        .result("(Literal #f)")
+        .result("(Undefined)")
         .diagnostic(24, 24, DiagnosticKind::err_expand_invalid_set)
         .check();
 }

--- a/src/libeval/tests/expander.rs
+++ b/src/libeval/tests/expander.rs
@@ -161,7 +161,7 @@ fn quote_nested() {
 fn quote_empty() {
     TestCase::new()
         .input("(quote)")
-        .result("(Quotation #f)")
+        .result("(Undefined)")
         .diagnostic(6, 6, DiagnosticKind::err_expand_invalid_quote)
         .check();
 }

--- a/src/libeval/tests/expander.rs
+++ b/src/libeval/tests/expander.rs
@@ -292,7 +292,7 @@ fn if_nested() {
 fn if_forms_0() {
     TestCase::new()
         .input("( if )")
-        .result("(Alternative (Literal #f) (Literal #f) (Literal #f))")
+        .result("(Alternative (Undefined) (Undefined) (Undefined))")
         .diagnostic(4, 5, DiagnosticKind::err_expand_invalid_if)
         .check();
 }
@@ -301,7 +301,7 @@ fn if_forms_0() {
 fn if_forms_1() {
     TestCase::new()
         .input("( if #false )")
-        .result("(Alternative (Literal #f) (Literal #f) (Literal #f))")
+        .result("(Alternative (Literal #f) (Undefined) (Undefined))")
         .diagnostic(11, 12, DiagnosticKind::err_expand_invalid_if)
         .check();
 }
@@ -310,7 +310,7 @@ fn if_forms_1() {
 fn if_forms_1_dotted() {
     TestCase::new()
         .input("(if . #f)")
-        .result("(Alternative (Literal #f) (Literal #f) (Literal #f))")
+        .result("(Alternative (Literal #f) (Undefined) (Undefined))")
         .diagnostic(8, 8, DiagnosticKind::err_expand_invalid_if)
         .diagnostic(3, 6, DiagnosticKind::err_expand_invalid_if)
         .check();
@@ -320,7 +320,7 @@ fn if_forms_1_dotted() {
 fn if_forms_2() {
     TestCase::new()
         .input("(if #f 1)")
-        .result("(Alternative (Literal #f) (Literal 1) (Literal #f))")
+        .result("(Alternative (Literal #f) (Literal 1) (Undefined))")
         .diagnostic(8, 8, DiagnosticKind::err_expand_invalid_if)
         .check();
 }
@@ -329,7 +329,7 @@ fn if_forms_2() {
 fn if_forms_2_dotted() {
     TestCase::new()
         .input("(if #f . 1)")
-        .result("(Alternative (Literal #f) (Literal 1) (Literal #f))")
+        .result("(Alternative (Literal #f) (Literal 1) (Undefined))")
         .diagnostic(10, 10, DiagnosticKind::err_expand_invalid_if)
         .diagnostic( 6,  9, DiagnosticKind::err_expand_invalid_if)
         .check();

--- a/src/libeval/tests/expander.rs
+++ b/src/libeval/tests/expander.rs
@@ -238,7 +238,7 @@ fn begin_nested() {
 fn begin_empty() {
     TestCase::new()
         .input("(begin)")
-        .result("(Sequence)")
+        .result("(Undefined)")
         .diagnostic(6, 6, DiagnosticKind::err_expand_invalid_begin)
         .check();
 }


### PR DESCRIPTION
We've been arbitrarily using `#f` as a placeholder value for missing terms. Stop doing this and introduce an explicit expression which denotes an undefined value. Use it in macro expanders for error recovery.